### PR TITLE
Make LOL validation patch sampling deterministic (center crop)

### DIFF
--- a/custom_utils/data_loaders/lol.py
+++ b/custom_utils/data_loaders/lol.py
@@ -67,6 +67,24 @@ class _BasePairDataset(Dataset):
         tar = TF.crop(tar, i, j, th, tw)
         return inp, tar
 
+    def _center_crop(self, inp, tar):
+        if self.patch_size <= 0:
+            return inp, tar
+
+        w, h = inp.size
+        if w < self.patch_size or h < self.patch_size:
+            pad_w = max(0, self.patch_size - w)
+            pad_h = max(0, self.patch_size - h)
+            inp = TF.pad(inp, (0, 0, pad_w, pad_h))
+            tar = TF.pad(tar, (0, 0, pad_w, pad_h))
+            w, h = inp.size
+
+        i = (h - self.patch_size) // 2
+        j = (w - self.patch_size) // 2
+        inp = TF.crop(inp, i, j, self.patch_size, self.patch_size)
+        tar = TF.crop(tar, i, j, self.patch_size, self.patch_size)
+        return inp, tar
+
 
 class PatchDataLoaderTrain(_BasePairDataset):
     def __init__(self, images_path, options):
@@ -84,7 +102,7 @@ class PatchDataLoaderVal(_BasePairDataset):
 
     def __getitem__(self, index):
         inp, tar = self._load_pair(index)
-        inp, tar = self._random_crop(inp, tar)
+        inp, tar = self._center_crop(inp, tar)
         return TF.to_tensor(inp), TF.to_tensor(tar)
 
 


### PR DESCRIPTION
### Motivation
- The validation loader `PatchDataLoaderVal` used `_random_crop`, which changed validation patches each epoch and introduced metric noise that can mislead checkpoint selection.

### Description
- Added a deterministic `_center_crop` helper on `_BasePairDataset` that preserves existing small-image padding behavior and returns a centered `patch_size` crop.
- Switched `PatchDataLoaderVal.__getitem__` to use `_center_crop` instead of `_random_crop`, while leaving `PatchDataLoaderTrain` unchanged so training augmentation remains random.

### Testing
- Ran `python -m compileall custom_utils/data_loaders/lol.py`, which completed successfully.
- Attempted a quick runtime determinism check with a temporary image pair, but the environment is missing the `PIL` dependency and the check failed with `ModuleNotFoundError`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698957bce080832c8f843c44a4cae163)